### PR TITLE
Removed preceding current directory dot and slash

### DIFF
--- a/tinypng-cli.js
+++ b/tinypng-cli.js
@@ -81,6 +81,8 @@ if (argv.v || argv.version) {
             console.log(chalk.bold('Processing...'));
 
             unique.forEach(function(file) {
+                
+                file = file.replace(/^\.\//, '');
 
                 fs.createReadStream(file).pipe(request.post('https://api.tinypng.com/shrink', {
                     auth: {


### PR DESCRIPTION
For deep structures, the createReadStream method fails when presented with ./path/to/image.png but works with path/to/image.png. That reflects the example in the Node docs: http://nodejs.org/api/fs.html#fs_fs_createreadstream_path_options

I came across this when trying to apply the (really great) tool recursively to my WordPress uploads directory, which is a few levels deep (eg. uploads/2015/01/image.png).