### PR TITLE
Add support for different resize methods

### DIFF
--- a/tinypng-cli.js
+++ b/tinypng-cli.js
@@ -33,6 +33,7 @@ if (argv.v || argv.version) {
     '  -r, --recursive  Walk given directory recursively\n' +
     '  --width          Resize an image to a specified width\n' +
     '  --height         Resize an image to a specified height\n' +
+    '  --resize-mode    Specify the resize method to use (scale, fit or cover)\n',
     '  -v, --version    Show installed version\n' +
     '  -h, --help       Show help'
   );
@@ -46,6 +47,7 @@ if (argv.v || argv.version) {
 
   var key = '';
   var resize = {};
+  var resize_modes = ['scale', 'fit', 'cover'];
 
   if (argv.k || argv.key) {
     key = typeof(argv.k || argv.key) === 'string' ? (argv.k || argv.key).trim() : '';
@@ -66,6 +68,19 @@ if (argv.v || argv.version) {
       resize.height = argv.height;
     } else {
       console.log(chalk.bold.red('Invalid height specified. Please specify a numeric value only.'));
+    }
+  }
+
+  if (argv['resize-method']) {
+    if (typeof(argv['resize-method']) === 'string' && resize_modes.includes(argv['resize-method'].toLowerCase()))
+    {
+      if (argv['resize-method'] != 'scale' && resize.width === undefined || argv['resize-method'] != 'scale' && resize.height === undefined) {
+        console.log(chalk.bold.red('This resize mode requires you to specify a width and a height.'));      
+      } else {
+        resize.method = argv['resize-method'];
+      }
+    } else {
+      console.log(chalk.bold.red(`Invalid resize mode specified. Valid modes are: ${resize_modes.join(', ')}`));      
     }
   }
 


### PR DESCRIPTION
This adds support for the three (or actually just two, as the default has always been scale) new resize modes in the tinypng API:

- scale: Scales the image down proportionally. You must provide either a target width or a target height, but not both. The scaled image will have exactly the provided width or height.
- fit: Scales the image down proportionally so that it fits within the given dimensions. You must provide both a width and a height. The scaled image will not exceed either of these dimensions.
- cover: Scales the image proportionally and crops it if necessary so that the result has exactly the given dimensions. You must provide both a width and a height. Which parts of the image are cropped away is determined automatically. An intelligent algorithm determines the most important areas and leaves these intact. 
