### PR TITLE
Add webp-support

### DIFF
--- a/tinypng-cli.js
+++ b/tinypng-cli.js
@@ -127,11 +127,11 @@ if (argv.v || argv.version) {
                         glob.sync(
                             file +
                                 (argv.r || argv.recursive ? "/**" : "") +
-                                "/*.+(png|jpg|jpeg|PNG|JPG|JPEG)"
+                                "/*.+(png|jpg|jpeg|PNG|JPG|JPEG|webp|WEBP)"
                         )
                     );
                 } else if (
-                    minimatch(file, "*.+(png|jpg|jpeg|PNG|JPG|JPEG)", {
+                    minimatch(file, "*.+(png|jpg|jpeg|PNG|JPG|JPEG|webp|WEBP)", {
                         matchBase: true
                     })
                 ) {


### PR DESCRIPTION
As the tinypng-backend supports webp, i checked my change already and it looked fine
![Screenshot_20220825_151616](https://user-images.githubusercontent.com/90995/186675295-1a85c771-6a95-42ef-97f9-c06ed11d1a1b.png)

Just saw this is a duplicate of #32 , but will leave it as there are less changes (by less formating) which makes the differences more readable.