### PR TITLE
Fix resize: Adds `scale` as default method

### DIFF
--- a/tinypng-cli.js
+++ b/tinypng-cli.js
@@ -56,7 +56,7 @@ if (argv.v || argv.version) {
     var files = argv._.length ? argv._ : ["."];
 
     var key = "";
-    var resize = {};
+    var resize = {method: 'scale'};
     var max = argv.m || argv.max ? (argv.m || argv.max) + 0 : -1;
 
     if (!argv["dry-run"]) {


### PR DESCRIPTION
Resize no longer works work unless this attribute is added. There are others that could work (https://tinypng.com/developers/reference) but this mirrors the original functionality of this package.